### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,7 @@ $requestTimer->stop();
 // Export metrics
 $exporter = new StoredMetricsExporter(
     $registry,
-    $storage,
-    new NullLogger(),
+    $storage
 );
 
 foreach ($exporter->export() as $metricOutput) {


### PR DESCRIPTION
`StoredMetricsExporter` doesn't have logger dependency